### PR TITLE
master -> main branch in example

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,7 +3,7 @@ name: "Terraform"
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
@@ -66,5 +66,5 @@ jobs:
         run: exit 1
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform apply -auto-approve


### PR DESCRIPTION
the default branch name for new repos is main. People will likely copy this code into their repo, and hit a snag when they try to set up this action in their infra repo.

I propose changing the default branch to main to follow GH's convention of base branch names for a new repo.