### PR TITLE
use outcome for validate output

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -47,7 +47,7 @@ jobs:
           script: |
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### Terraform Validation 🤖\`${{ steps.validate.outputs.stdout }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
             #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
 
             <details><summary>Show Plan</summary>


### PR DESCRIPTION
I intended to edit the example itself, and so I'm re-opening this PR as instructed.

outputs.stdout breaks code formatting in the generated PR comment due to a trailing newline.

steps.validate.outcome is consistent with the other  steps, and it appears to suffice.