### PR TITLE
Remove pessimistic contraint operator causing Github Action to fail

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ terraform {
       version = "3.0.1"
     }
   }
-  required_version = "~> 0.14"
+  required_version = ">= 0.14"
 
   backend "remote" {
     organization = "REPLACE_ME"


### PR DESCRIPTION
Resolve the following error in Terraform Github Action run

> Error: Unsupported Terraform Core version
> 
>  on main.tf line 12, in terraform:
>  12: required_version = "~> 0.14"
>  
>  This configuration does not support Terraform version 1.0.3. To proceed,
>  either choose another supported Terraform version or update this version
>  constraint. Version constraints are normally set for good reason, so
>  updating the constraint may lead to other errors or unexpected behavior.