### PR TITLE
fix(your-fork): change repo-token to github_token

### DIFF
--- a/.github/workflows/your-fork.yml
+++ b/.github/workflows/your-fork.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: superbrothers/close-pull-request@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         # Optional. Post a issue comment just before closing a pull request.
         comment: "Hi! If you are following the Terraform GitHub Actions tutorial, please open the PR against [your personal fork](https://learn.hashicorp.com/tutorials/terraform/github-actions?in=terraform/automation#set-up-a-github-repository) of this repository. We will automatically close this PR, but if you intended to edit the example itself please feel free to re-open it."


### PR DESCRIPTION
The `superbrothers/close-pull-request@v3` action does not have an argument called `repo-token`. It does however, have an argument called `github_token`.

For reference: https://github.com/superbrothers/close-pull-request/blob/master/action.yml