### PR TITLE
fix typo in terraform.yml

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Terraform"
     runs-on: ubuntu-latest
     permissions:
-      pull-request: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
According to github doc and also according to workflow configuration it should be "pull-requests" not "pull-request" https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs